### PR TITLE
Todo Table 'Create/New' Action

### DIFF
--- a/src/Controller/TodoController.php
+++ b/src/Controller/TodoController.php
@@ -13,7 +13,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 class TodoController extends AbstractController
 {
     /**
-     * @Route("/todos/{id}", name="todo_show")
+     * @Route("/todo/{id}", name="todo_show")
      */
     public function show($id)
     {

--- a/src/Controller/TodoController.php
+++ b/src/Controller/TodoController.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class TodoController extends AbstractController
 {
     /**
-     * @Route("/todo/{id}", name="todo_show")
+     * @Route("/todos/{id}", name="todo_show")
      */
     public function show($id)
     {
@@ -24,6 +24,14 @@ class TodoController extends AbstractController
       }
 
       return $this->render('todo/show.html.twig', ['todo' => $todo]); //Need to create Template to display queried $todo object
+
+    }
+
+    /**
+    * @Route("/todos/new", name="todo_new")
+    */
+    public function new()
+    {
 
     }
 }

--- a/src/Controller/TodoController.php
+++ b/src/Controller/TodoController.php
@@ -3,10 +3,12 @@
 namespace App\Controller;
 
 use App\Entity\Todo;
+use App\Form\Type\TodoType;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
 class TodoController extends AbstractController
 {

--- a/src/Controller/TodoController.php
+++ b/src/Controller/TodoController.php
@@ -32,8 +32,14 @@ class TodoController extends AbstractController
     /**
     * @Route("/todos/new", name="todo_new")
     */
-    public function new()
+    public function new(Request $request)
     {
+      $todo = new Todo();
 
+      $form = $this->createForm(TodoType::class, $todo);
+
+      return $this->render('task/new.html.twig', [
+        'form' => $form->createView(),
+      ]);
     }
 }

--- a/src/Controller/TodoController.php
+++ b/src/Controller/TodoController.php
@@ -26,7 +26,6 @@ class TodoController extends AbstractController
       }
 
       return $this->render('todo/show.html.twig', ['todo' => $todo]); //Need to create Template to display queried $todo object
-
     }
 
     /**
@@ -38,7 +37,7 @@ class TodoController extends AbstractController
 
       $form = $this->createForm(TodoType::class, $todo);
 
-      return $this->render('task/new.html.twig', [
+      return $this->render('todo/new.html.twig', [
         'form' => $form->createView(),
       ]);
     }

--- a/src/Controller/TodoController.php
+++ b/src/Controller/TodoController.php
@@ -37,6 +37,17 @@ class TodoController extends AbstractController
 
       $form = $this->createForm(TodoType::class, $todo);
 
+      $form->handleRequest($request);
+      if ($form->isSubmitted() && $form->isValid()) {
+
+          $task = $form->getData();
+
+          $entityManager = $this->getDoctrine()->getManager();
+          $entityManager->persist($task);
+          $entityManager->flush();
+
+          return $this->redirectToRoute('todo_index');
+      }
       return $this->render('todo/new.html.twig', [
         'form' => $form->createView(),
       ]);

--- a/src/Form/Type/TodoType.php
+++ b/src/Form/Type/TodoType.php
@@ -4,6 +4,7 @@ namespace App\Form\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 use App\Entity\Todo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -14,6 +15,9 @@ class TodoType extends AbstractType
     {
         $builder
             ->add('task', TextType::class)
+            ->add('status', HiddenType::class, [
+              'data' => 'Incomplete'
+            ])
             ->add('save', SubmitType::class)
         ;
     }

--- a/src/Form/Type/TodoType.php
+++ b/src/Form/Type/TodoType.php
@@ -5,6 +5,8 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use App\Entity\Todo;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class TodoType extends AbstractType
 {
@@ -14,5 +16,12 @@ class TodoType extends AbstractType
             ->add('task', TextType::class)
             ->add('save', SubmitType::class)
         ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'data_class' => Todo::class,
+        ]);
     }
 }

--- a/src/Form/Type/TodoType.php
+++ b/src/Form/Type/TodoType.php
@@ -1,0 +1,18 @@
+<?php
+namespace App\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class TodoType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('task', TextType::class)
+            ->add('save', SubmitType::class)
+        ;
+    }
+}

--- a/src/Form/Type/TodoType.php
+++ b/src/Form/Type/TodoType.php
@@ -6,8 +6,8 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
-use App\Entity\Todo;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use App\Entity\Todo;
 
 class TodoType extends AbstractType
 {
@@ -18,7 +18,9 @@ class TodoType extends AbstractType
             ->add('status', HiddenType::class, [
               'data' => 'Incomplete'
             ])
-            ->add('save', SubmitType::class)
+            ->add('save', SubmitType::class, [
+              'label' => 'Create Task'
+            ])
         ;
     }
 

--- a/templates/todo/new.html.twig
+++ b/templates/todo/new.html.twig
@@ -1,0 +1,3 @@
+<h1>Create a new Task</h1>
+
+{{ form(form) }}


### PR DESCRIPTION
Create TodoController's 'New' Action to determine if a form should be rendered or processed for db entry. 

Create TodoType form builder for defining the New Todo Task form to be used in the TodoController's 'New' Action. 

Create new.html.twig to render New Todo Task form.


When visiting `/todos/new` the TodoController will render the Todo Task form. Upon submission the controller will create a new Todo record using the 'Task' value defined in the form along with a default 'Status' of "Incomplete". The user will then be redirected to the todo_index page.

Happy/Sad path handling and success flash messages need to be added.

Closes #2 